### PR TITLE
insert eharts.common.min.js in templates

### DIFF
--- a/echarts-template.html
+++ b/echarts-template.html
@@ -1,4 +1,5 @@
 <div id="<%- id %>" style="width: <%- width %>;height: <%- height %>px;margin: 0 auto"></div>
+<script src="http://echarts.baidu.com/dist/echarts.common.min.js"></script>
 <script type="text/javascript">
         // 基于准备好的dom，初始化echarts实例
         var myChart = echarts.init(document.getElementById('<%- id %>'));


### PR DESCRIPTION
insert eharts.common.min.js in templates so that you needn't to modify theme's layout. because:
- not every post need echarts resource
- plugin should get things done